### PR TITLE
Fix $IMAGE variable.

### DIFF
--- a/post-release
+++ b/post-release
@@ -1,5 +1,5 @@
 #!/bin/bash
-APP="$1"; IMAGE="$2"
+APP="$1"; IMAGE="app/$APP"
 
 read -d '' runner <<'EOF'
 #!/bin/bash


### PR DESCRIPTION
In the current version of dokku the $IMAGE variable is no longer passed in to pluginhooks, causing this script to break. The fix is easy, just need to change it from being `IMAGE="$2"` to `IMAGE="app/$APP"`.

More details about the fix, and the commit that changed this, here:
https://github.com/progrium/dokku/issues/313#issuecomment-31210408
